### PR TITLE
채팅이 없는 경우 치지직서버에서 소켓을 끊는 문제 해결

### DIFF
--- a/src/main/java/xyz/r2turntrue/chzzk4j/chat/WsMessageServerboundPing.java
+++ b/src/main/java/xyz/r2turntrue/chzzk4j/chat/WsMessageServerboundPing.java
@@ -1,0 +1,6 @@
+package xyz.r2turntrue.chzzk4j.chat;
+
+class WsMessageServerboundPing {
+    public int cmd = WsMessageTypes.Commands.PING;
+    public String ver = "2";
+}


### PR DESCRIPTION
멋진 프로젝트를 공개해주셔서 감사합니다.

사용하던 중에 채팅이 없는 경우 주기적으로 재 연결하는 문제를 간단하게 수정하였습니다.

1. 마지막 핑 시간으로 부터 1분이 지난 경우
2. 마지막 메시지가 도착한 뒤로 부터 20초가 지났을 경우