### PR TITLE
Client 인증 API를 올바르게 사용하도록 수정

### DIFF
--- a/src/main/java/xyz/r2turntrue/chzzk4j/session/ChzzkSession.java
+++ b/src/main/java/xyz/r2turntrue/chzzk4j/session/ChzzkSession.java
@@ -215,8 +215,17 @@ class ChzzkSession {
     public CompletableFuture<Void> createAndConnectAsync() {
         return CompletableFuture.runAsync(() -> {
             try {
-                JsonElement urlRaw = RawApiUtils.getContentJson(chzzk.getHttpClient(),
-                                RawApiUtils.httpGetRequest(ChzzkClient.OPENAPI_URL + sessionCreateUrl).build(), chzzk.isDebug)
+                Request.Builder requestBuilder = RawApiUtils.httpGetRequest(ChzzkClient.OPENAPI_URL + sessionCreateUrl);
+
+                String clientId = chzzk.getApiClientId();
+                String clientSecret = chzzk.getApiSecret();
+
+                if (clientId != null && clientSecret != null) {
+                    requestBuilder.addHeader("Client-Id", clientId);
+                    requestBuilder.addHeader("Client-Secret", clientSecret);
+                }
+
+                JsonElement urlRaw = RawApiUtils.getContentJson(chzzk.getHttpClient(), requestBuilder.build(), chzzk.isDebug)
                         .getAsJsonObject()
                         .get("url");
 


### PR DESCRIPTION
안녕하세요! 만들어주신 라이브러리 정말 잘 사용하고 있습니다! 사용중에 버그를 발견하여 PR을 올립니다.

https://chzzk.gitbook.io/chzzk/chzzk-api/tips#client-api

위 문서 내용에 따르면, Client 인증 API의 경우 Header를 통해 인증 정보를 전달해야 합니다. 이는 아래와 같이 Client 세션 생성시 필요합니다.

https://chzzk.gitbook.io/chzzk/chzzk-api/session#undefined

이 PR은 Client Id 및 Secret이 주어진 경우 Header에 반영하여 세션 연결이 가능하도록 합니다.