### PR TITLE
Concurrency 해결 및 빌드, 테스트 환경 게선

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,3 @@
-import java.io.BufferedInputStream
-import java.io.InputStream
-import java.lang.IllegalStateException
 import java.util.Properties
 
 plugins {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,15 +13,17 @@ group = "io.github.r2turntrue"
 version = "0.1.4"
 
 val publishProps = Properties()
-publishProps.load(
-    File("publish.properties").inputStream())
+val publishPropsFile = File("publish.properties")
+if (publishPropsFile.exists()) {
+    publishProps.load(publishPropsFile.inputStream())
+}
 
-ext["signing.keyId"] = publishProps["signing.keyId"]
-ext["signing.password"] = publishProps["signing.password"]
-ext["signing.secretKeyRingFile"] = publishProps["signing.secretKeyRingFile"]
+ext["signing.keyId"] = publishProps["signing.keyId"] ?: ""
+ext["signing.password"] = publishProps["signing.password"] ?: ""
+ext["signing.secretKeyRingFile"] = publishProps["signing.secretKeyRingFile"] ?: ""
 
-val sonatypeUsername = publishProps["nexusUsername"] as String
-val sonatypePassword = publishProps["nexusPassword"] as String
+val sonatypeUsername = (publishProps["nexusUsername"] as? String) ?: ""
+val sonatypePassword = (publishProps["nexusPassword"] as? String) ?: ""
 
 repositories {
     mavenCentral()

--- a/src/main/java/xyz/r2turntrue/chzzk4j/ChzzkClient.java
+++ b/src/main/java/xyz/r2turntrue/chzzk4j/ChzzkClient.java
@@ -468,6 +468,12 @@ public class ChzzkClient {
                 emoticons = gson.fromJson(
                         emoteElement,
                         ChzzkChannelEmotePackData.class);
+            if (contentJson != null && contentJson.isJsonObject()) {
+                var jsonObject = contentJson.getAsJsonObject();
+                if (jsonObject.has("subscriptionEmojiPacks")) {
+                    var emoteElements = jsonObject.getAsJsonArray("subscriptionEmojiPacks");
+
+                }
             }
             return emoticons;
         });

--- a/src/main/java/xyz/r2turntrue/chzzk4j/ChzzkClient.java
+++ b/src/main/java/xyz/r2turntrue/chzzk4j/ChzzkClient.java
@@ -34,7 +34,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CompletionException;
 
 public class ChzzkClient {
     public static final String API_URL = "https://api.chzzk.naver.com";
@@ -130,11 +130,11 @@ public class ChzzkClient {
                 );
 
                 for (ChzzkLoginAdapter adapter : loginAdapters) {
-                    ChzzkLoginResult result = null;
+                    ChzzkLoginResult result;
                     try {
-                        result = adapter.authorize(this).get();
-                    } catch (InterruptedException | ExecutionException e) {
-                        throw new RuntimeException(e);
+                        result = adapter.authorize(this).join();
+                    } catch (Exception e) {
+                        throw new CompletionException(e);
                     }
 
                     if (result.accessToken() != null) {

--- a/src/main/java/xyz/r2turntrue/chzzk4j/ChzzkClient.java
+++ b/src/main/java/xyz/r2turntrue/chzzk4j/ChzzkClient.java
@@ -37,9 +37,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 public class ChzzkClient {
-    public static String API_URL = "https://api.chzzk.naver.com";
-    public static String GAME_API_URL = "https://comm-api.game.naver.com/nng_main";
-    public static String OPENAPI_URL = "https://openapi.chzzk.naver.com";
+    public static final String API_URL = "https://api.chzzk.naver.com";
+    public static final String GAME_API_URL = "https://comm-api.game.naver.com/nng_main";
+    public static final String OPENAPI_URL = "https://openapi.chzzk.naver.com";
 
     public boolean isDebug = false;
 

--- a/src/main/java/xyz/r2turntrue/chzzk4j/ChzzkClient.java
+++ b/src/main/java/xyz/r2turntrue/chzzk4j/ChzzkClient.java
@@ -281,7 +281,7 @@ public class ChzzkClient {
     public CompletableFuture<ChzzkChannel[]> fetchChannelsOpenApi(String... channelIds) {
         if (!hasApiKey) throw new IllegalStateException("Can't fetch channels without the OpenAPI key!");
         return CompletableFuture.supplyAsync(() -> {
-            JsonObject contentJson = null;
+            JsonObject contentJson;
             try {
                 String idsParam = String.join(",", channelIds);
                 contentJson = RawApiUtils.getContentJson(
@@ -301,7 +301,7 @@ public class ChzzkClient {
         if (isLegacyOnly) throw new IllegalStateException("Can't fetch channel managers without logging in with access token!");
 
         return CompletableFuture.supplyAsync(() -> {
-            JsonObject contentJson = null;
+            JsonObject contentJson;
             try {
                 contentJson = RawApiUtils.getContentJson(
                         httpClient,
@@ -332,7 +332,7 @@ public class ChzzkClient {
         if (isLegacyOnly) throw new IllegalStateException("Can't fetch followers without logging in with access token!");
 
         return CompletableFuture.supplyAsync(() -> {
-            JsonObject contentJson = null;
+            JsonObject contentJson;
 
             try {
                 contentJson = RawApiUtils.getContentJson(
@@ -354,7 +354,7 @@ public class ChzzkClient {
         if (isLegacyOnly) throw new IllegalStateException("Can't fetch subscribers without logging in with access token!");
 
         return CompletableFuture.supplyAsync(() -> {
-            JsonObject contentJson = null;
+            JsonObject contentJson;
             try {
                 contentJson = RawApiUtils.getContentJson(
                         httpClient,
@@ -378,7 +378,7 @@ public class ChzzkClient {
      */
     public @NotNull CompletableFuture<ChzzkLiveStatus> fetchLiveStatus(@NotNull String channelId) {
         return CompletableFuture.supplyAsync(() -> {
-            JsonElement contentJson = null;
+            JsonElement contentJson;
             try {
                 contentJson = RawApiUtils.getContentJson(
                         httpClient,
@@ -399,7 +399,7 @@ public class ChzzkClient {
      */
     public @NotNull CompletableFuture<ChzzkLiveDetail> fetchLiveDetail(@NotNull String channelId) {
         return CompletableFuture.supplyAsync(() -> {
-            JsonElement contentJson = null;
+            JsonElement contentJson;
             try {
                 contentJson = RawApiUtils.getContentJson(
                         httpClient,
@@ -421,7 +421,7 @@ public class ChzzkClient {
      */
     public CompletableFuture<ChzzkChannelRules> fetchChannelChatRules(String channelId) {
         return CompletableFuture.supplyAsync(() -> {
-            JsonElement contentJson = null;
+            JsonElement contentJson;
             try {
                 contentJson = RawApiUtils.getContentJson(
                         httpClient,
@@ -449,7 +449,7 @@ public class ChzzkClient {
 
     public CompletableFuture<ChzzkChannelEmotePackData> fetchChannelEmotePackData(String channelId) {
         return CompletableFuture.supplyAsync(() -> {
-            JsonElement contentJson = null;
+            JsonElement contentJson;
             try {
                 contentJson = RawApiUtils.getContentJson(
                         httpClient,
@@ -458,6 +458,7 @@ public class ChzzkClient {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
+
             ChzzkChannelEmotePackData emoticons = null;
             List<JsonElement> emoteElements = contentJson.getAsJsonObject().asMap().get("subscriptionEmojiPacks").getAsJsonArray().asList();
             for (JsonElement emoteElement : emoteElements) {
@@ -489,7 +490,7 @@ public class ChzzkClient {
         }
 
         return CompletableFuture.supplyAsync(() -> {
-            JsonElement contentJson = null;
+            JsonElement contentJson;
             try {
                 contentJson = RawApiUtils.getContentJson(
                         httpClient,
@@ -530,7 +531,7 @@ public class ChzzkClient {
         }
 
         return CompletableFuture.supplyAsync(() -> {
-            JsonElement contentJson = null;
+            JsonElement contentJson;
             try {
                 contentJson = RawApiUtils.getContentJson(
                         httpClient,
@@ -563,7 +564,7 @@ public class ChzzkClient {
 
         if (isOauthOnly) {
             return CompletableFuture.supplyAsync(() -> {
-                JsonObject contentJson = null;
+                JsonObject contentJson;
                 try {
                     contentJson = RawApiUtils.getContentJson(
                             httpClient,
@@ -587,7 +588,7 @@ public class ChzzkClient {
         }
 
         return CompletableFuture.supplyAsync(() -> {
-            JsonElement contentJson = null;
+            JsonElement contentJson;
             try {
                 contentJson = RawApiUtils.getContentJson(
                         httpClient,
@@ -614,7 +615,7 @@ public class ChzzkClient {
         }
 
         return CompletableFuture.supplyAsync(() -> {
-            JsonObject contentJson = null;
+            JsonObject contentJson;
             try {
                 contentJson = RawApiUtils.getContentJson(
                         httpClient,
@@ -872,12 +873,12 @@ public class ChzzkClient {
         return CompletableFuture.runAsync(() -> {
             try {
                 RawApiUtils.getContentJson(getHttpClient(), RawApiUtils.httpPostRequest(ChzzkClient.OPENAPI_URL + "/auth/v1/token/revoke",
-                                        gson.toJson(new TokenRevokeRequestBody(
-                                                apiClientId,
-                                                apiSecret,
-                                                token,
-                                                tokenTypeHint
-                                        ))).build(), isDebug);
+                        gson.toJson(new TokenRevokeRequestBody(
+                                apiClientId,
+                                apiSecret,
+                                token,
+                                tokenTypeHint
+                        ))).build(), isDebug);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/src/main/java/xyz/r2turntrue/chzzk4j/ChzzkClient.java
+++ b/src/main/java/xyz/r2turntrue/chzzk4j/ChzzkClient.java
@@ -460,19 +460,24 @@ public class ChzzkClient {
             }
 
             ChzzkChannelEmotePackData emoticons = null;
-            List<JsonElement> emoteElements = contentJson.getAsJsonObject().asMap().get("subscriptionEmojiPacks").getAsJsonArray().asList();
-            for (JsonElement emoteElement : emoteElements) {
-                if (emoteElement.getAsJsonObject().asMap().get("emojiPackId").getAsString().equals("\"" + channelId + "\"")) {
-                    continue;
-                }
-                emoticons = gson.fromJson(
-                        emoteElement,
-                        ChzzkChannelEmotePackData.class);
             if (contentJson != null && contentJson.isJsonObject()) {
                 var jsonObject = contentJson.getAsJsonObject();
                 if (jsonObject.has("subscriptionEmojiPacks")) {
                     var emoteElements = jsonObject.getAsJsonArray("subscriptionEmojiPacks");
 
+                    for (JsonElement emoteElement : emoteElements) {
+                        var elementObj = emoteElement.getAsJsonObject();
+                        if (!elementObj.has("emojiPackId")) continue;
+
+                        // getAsString()은 이미 따옴표가 제거된 상태이므로 직접 비교
+                        String emojiPackId = elementObj.get("emojiPackId").getAsString();
+
+                        if (emojiPackId.equals(channelId)) {
+                            // 일치하는 데이터를 찾았으므로 객체 변환 후 루프 탈출
+                            emoticons = gson.fromJson(emoteElement, ChzzkChannelEmotePackData.class);
+                            break;
+                        }
+                    }
                 }
             }
             return emoticons;

--- a/src/main/java/xyz/r2turntrue/chzzk4j/session/ChzzkSession.java
+++ b/src/main/java/xyz/r2turntrue/chzzk4j/session/ChzzkSession.java
@@ -22,7 +22,6 @@ import xyz.r2turntrue.chzzk4j.util.RawApiUtils;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;

--- a/src/main/java/xyz/r2turntrue/chzzk4j/session/ChzzkSession.java
+++ b/src/main/java/xyz/r2turntrue/chzzk4j/session/ChzzkSession.java
@@ -24,9 +24,10 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 
@@ -45,7 +46,7 @@ class ChzzkSession {
     protected String sessionCreateUrl = "/open/v1/sessions/auth";
     protected boolean userSession = false;
 
-    HashMap<Class<? extends SessionEvent>, ArrayList<Consumer<? extends SessionEvent>>> handlerMap = new HashMap<>();
+    ConcurrentHashMap<Class<? extends SessionEvent>, CopyOnWriteArrayList<Consumer<? extends SessionEvent>>> handlerMap = new ConcurrentHashMap<>();
 
     private ChzzkClient chzzk;
     private boolean autoRecreate = true;
@@ -53,8 +54,8 @@ class ChzzkSession {
     private boolean disconnectedForce = true;
     private String sessionKey = "";
 
-    private List<ChzzkSessionSubscriptionType> subscriptions = new ArrayList<>();
-    private List<ChzzkSessionSubscriptionType> appliedSubscriptions = new ArrayList<>();
+    private final List<ChzzkSessionSubscriptionType> subscriptions = new CopyOnWriteArrayList<>();
+    private final List<ChzzkSessionSubscriptionType> appliedSubscriptions = new CopyOnWriteArrayList<>();
 
     private Socket socket;
 
@@ -364,7 +365,7 @@ class ChzzkSession {
 
     public <T extends SessionEvent> void on(Class<T> clazz, Consumer<T> action) {
         if (!handlerMap.containsKey(clazz)) {
-            handlerMap.put(clazz, new ArrayList<>());
+            handlerMap.put(clazz, new CopyOnWriteArrayList<>());
         }
 
         handlerMap.get(clazz).add(action);

--- a/src/test/java/ChzzkTestBase.java
+++ b/src/test/java/ChzzkTestBase.java
@@ -1,9 +1,11 @@
+import org.junit.jupiter.api.Assumptions;
 import xyz.r2turntrue.chzzk4j.ChzzkClient;
 import xyz.r2turntrue.chzzk4j.ChzzkClientBuilder;
 import xyz.r2turntrue.chzzk4j.auth.ChzzkLegacyLoginAdapter;
 import xyz.r2turntrue.chzzk4j.auth.ChzzkLoginAdapter;
 import xyz.r2turntrue.chzzk4j.naver.NaverAutologinAdapter;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Properties;
@@ -22,6 +24,7 @@ public class ChzzkTestBase {
     }
 
     public ChzzkTestBase(boolean naverLogin) {
+        Assumptions.assumeTrue(new File("env.properties").exists(), "env.properties not found, skipping integration tests");
         try {
             properties.load(new FileInputStream("env.properties"));
         } catch (IOException e) {


### PR DESCRIPTION
버그 수정

- fetchChannelEmotePackData: 이모티콘 팩 ID 비교 로직 수정 — asMap().get() 대신 GSON 내장 메서드를 사용하고, getAsString()이 이미 따옴표를 제거한 상태임을 감안하지 않아 항상 비교 실패하던 문제 수정
- loginAsync: CompletableFuture 내부에서 .get()(블로킹)을 사용해 데드락이 발생할 수 있던 문제를 .join()으로 교체

스레드 안전성 개선

- ChzzkSession의 handlerMap을 HashMap → ConcurrentHashMap으로, 이벤트 핸들러 리스트를 ArrayList → CopyOnWriteArrayList로 교체 — 여러 스레드에서 동시에 이벤트를 수신하거나 핸들러를 등록할

코드 품질

- API_URL, GAME_API_URL, OPENAPI_URL 상수에 final 추가
- 불필요한 null 초기화 제거 (로컬 변수 — 항상 try 블록에서 할당됨)

빌드 / 테스트 환경

- publish.properties 또는 env.properties가 없어도 빌드와 테스트가 실패하지 않도록 수정 — 로컬 자격증명 파일 없이 클론 후 바로 빌드 가능