### PR TITLE
feat: 임시제한 + 채팅 블라인드 기능 추가

### DIFF
--- a/src/main/java/xyz/r2turntrue/chzzk4j/ChzzkClient.java
+++ b/src/main/java/xyz/r2turntrue/chzzk4j/ChzzkClient.java
@@ -759,6 +759,50 @@ public class ChzzkClient {
         });
     }
 
+    public CompletableFuture<Void> blindMessage(String chatChannelId, long messageTime, String senderChannelId) {
+        if (!isLoggedIn) throw new IllegalStateException("Can't blind message without logging in!");
+        if (isLegacyOnly) throw new IllegalStateException("Can't blind message without logging in without access token!");
+        return CompletableFuture.runAsync(() -> {
+            try {
+                RawApiUtils.getContentJson(getHttpClient(), RawApiUtils.httpPostRequest(
+                        ChzzkClient.OPENAPI_URL + "/open/v1/chats/blind-message",
+                        gson.toJson(new BlindMessageRequestBody(chatChannelId, messageTime, senderChannelId))).build(), isDebug);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public CompletableFuture<Void> temporaryRestrict(String targetChannelId, String chatChannelId) {
+        if (!isLoggedIn) throw new IllegalStateException("Can't temporary restrict channel without logging in!");
+        if (isLegacyOnly) throw new IllegalStateException("Can't temporary restrict channel without logging in without access token!");
+
+        return CompletableFuture.runAsync(() -> {
+            try {
+                RawApiUtils.getContentJson(getHttpClient(), RawApiUtils.httpPostRequest(
+                        ChzzkClient.OPENAPI_URL + "/open/v1/temporary-restrict-channels",
+                        gson.toJson(new TemporaryRestrictChannelRequestBody(targetChannelId, chatChannelId))).build(), isDebug);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public CompletableFuture<Void> removeTemporaryRestrict(String targetChannelId, String chatChannelId) {
+        if (!isLoggedIn) throw new IllegalStateException("Can't remove temporary restrict channel without logging in!");
+        if (isLegacyOnly) throw new IllegalStateException("Can't remove temporary restrict channel without logging in without access token!");
+
+        return CompletableFuture.runAsync(() -> {
+            try {
+                RawApiUtils.getContentJson(getHttpClient(), RawApiUtils.httpDeleteRequest(
+                        ChzzkClient.OPENAPI_URL + "/open/v1/temporary-restrict-channels",
+                        gson.toJson(new TemporaryRestrictChannelRequestBody(targetChannelId, chatChannelId))).build(), isDebug);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
     public CompletableFuture<Void> restrictChannel(String targetChannelId) {
         if (!isLoggedIn) throw new IllegalStateException("Can't restrict channel without logging in!");
         if (isLegacyOnly) throw new IllegalStateException("Can't restrict channel without logging in without access token!");

--- a/src/main/java/xyz/r2turntrue/chzzk4j/session/message/SessionChatMessage.java
+++ b/src/main/java/xyz/r2turntrue/chzzk4j/session/message/SessionChatMessage.java
@@ -80,6 +80,7 @@ public class SessionChatMessage {
 
     private String channelId;
     private String senderChannelId;
+    private String chatChannelId;
 
     private Profile profile;
     private String content;
@@ -92,6 +93,10 @@ public class SessionChatMessage {
 
     public String getSenderChannelId() {
         return senderChannelId;
+    }
+
+    public String getChatChannelId() {
+        return chatChannelId;
     }
 
     public Profile getProfile() {
@@ -121,12 +126,12 @@ public class SessionChatMessage {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         SessionChatMessage that = (SessionChatMessage) o;
-        return messageTime == that.messageTime && Objects.equals(channelId, that.channelId) && Objects.equals(senderChannelId, that.senderChannelId) && Objects.equals(profile, that.profile) && Objects.equals(content, that.content) && Objects.equals(emojis, that.emojis);
+        return messageTime == that.messageTime && Objects.equals(channelId, that.channelId) && Objects.equals(senderChannelId, that.senderChannelId) && Objects.equals(chatChannelId, that.chatChannelId) && Objects.equals(profile, that.profile) && Objects.equals(content, that.content) && Objects.equals(emojis, that.emojis);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(channelId, senderChannelId, profile, content, emojis, messageTime);
+        return Objects.hash(channelId, senderChannelId, chatChannelId, profile, content, emojis, messageTime);
     }
 
     @Override
@@ -134,6 +139,7 @@ public class SessionChatMessage {
         return "SessionChatMessage{" +
                 "channelId='" + channelId + '\'' +
                 ", senderChannelId='" + senderChannelId + '\'' +
+                ", chatChannelId='" + chatChannelId + '\'' +
                 ", profile=" + profile +
                 ", content='" + content + '\'' +
                 ", emojis=" + emojis +

--- a/src/main/java/xyz/r2turntrue/chzzk4j/types/channel/BlindMessageRequestBody.java
+++ b/src/main/java/xyz/r2turntrue/chzzk4j/types/channel/BlindMessageRequestBody.java
@@ -1,0 +1,4 @@
+package xyz.r2turntrue.chzzk4j.types.channel;
+
+public record BlindMessageRequestBody(String chatChannelId, long messageTime, String senderChannelId) {
+}

--- a/src/main/java/xyz/r2turntrue/chzzk4j/types/channel/TemporaryRestrictChannelRequestBody.java
+++ b/src/main/java/xyz/r2turntrue/chzzk4j/types/channel/TemporaryRestrictChannelRequestBody.java
@@ -1,0 +1,4 @@
+package xyz.r2turntrue.chzzk4j.types.channel;
+
+public record TemporaryRestrictChannelRequestBody(String targetChannelId, String chatChannelId) {
+}


### PR DESCRIPTION
## 개요
  임시제한(임시 채팅 제한)과 채팅 메시지 블라인드 기능을 추가합니다.
  기존에는 `restrictChannel()` / `unrestrictChannel()` 로 **영구 활동 제한**만
  가능했고, 일정 시간만 막는 임시제한과 메시지 숨김은 지원하지 않았습니다.

Closes #32 

## 변경 사항
  ### 추가된 메서드 (`ChzzkClient`)
  - `temporaryRestrict(targetChannelId, chatChannelId)` — 임시제한 추가
    `POST /open/v1/temporary-restrict-channels`                                                                                                                                                                                                                                                                     
  - `removeTemporaryRestrict(targetChannelId, chatChannelId)` — 임시제한 해제
    `DELETE /open/v1/temporary-restrict-channels`                                                                                                                                                                                                                                                                   
  - `blindMessage(chatChannelId, messageTime, senderChannelId)` — 채팅 메시지 블라인드
    `POST /open/v1/chats/blind-message`

### 추가된 RequestBody record
  - `TemporaryRestrictChannelRequestBody`
  - `BlindMessageRequestBody`

### 기타                                                                                                                              
  - `SessionChatMessage`에 `chatChannelId` 필드 추가                                                                                                      
    → CHAT 이벤트 명세에 포함된 값이나 기존에 누락됨. 임시제한/블라인드 호출 시 필요.